### PR TITLE
Add missing require 'test_helper' to tests

### DIFF
--- a/test/channels/connection_test.rb
+++ b/test/channels/connection_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'test_helper'
+
 module ApplicationCable
   class ConnectionTest < ActionCable::Connection::TestCase
     def test_connects_with_token

--- a/test/channels/update_channel_test.rb
+++ b/test/channels/update_channel_test.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'test_helper'
+
 class UpdateChannelTest < ActionCable::Channel::TestCase
   def test_subscribe
     user = users(:harry)


### PR DESCRIPTION
This resolves an issue where running `rails test` would fail with a somewhat cryptic error message about `ActionCable` not being available.