### PR TITLE
Add migration for CVE-2018-1000211

### DIFF
--- a/db/migrate/20190517123457_add_confidential_to_doorkeeper_application.rb
+++ b/db/migrate/20190517123457_add_confidential_to_doorkeeper_application.rb
@@ -1,0 +1,11 @@
+class AddConfidentialToDoorkeeperApplication < ActiveRecord::Migration[5.2]
+  def change
+    add_column(
+      :oauth_applications,
+      :confidential,
+      :boolean,
+      null: false,
+      default: true # maintaining backwards compatibility: require secrets
+    )
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_09_19_150711) do
+ActiveRecord::Schema.define(version: 2019_05_17_123457) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -249,6 +249,7 @@ ActiveRecord::Schema.define(version: 2018_09_19_150711) do
     t.string "scopes", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "confidential", default: true, null: false
     t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 


### PR DESCRIPTION
This resolves a potential issue within the Doorkeeper gem where tokens might not be revoked when revocation is requested ([CVE-2018-1000211](https://nvd.nist.gov/vuln/detail/CVE-2018-1000211). In practice this doesn't matter as all clients are currently confidential clients anyway, which were unaffected. However this is a simple change and it should be made anyway.