### PR TITLE
Add password complexity

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,9 @@ gem 'puma', '~> 3.11'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'devise'
+# add security extension for password complexity
+gem 'devise_security_extension', git: 'https://github.com/phatworx/devise_security_extension.git'
+gem 'rails_email_validator'
 # These gems currently held back for potential compatibility issues - haven't verified that the latest versions work yet
 gem 'doorkeeper', '~> 4.4'
 gem 'fhir_client', '~> 3.0.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/phatworx/devise_security_extension.git
+  revision: b2ee978af7d49f0fb0e7271c6ac074dfb4d39353
+  specs:
+    devise_security_extension (0.10.0)
+      devise (>= 3.0.0, < 5.0)
+      railties (>= 3.2.6, < 6.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -170,6 +178,8 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
+    rails_email_validator (0.1.4)
+      activemodel (>= 3.0.0)
     railties (5.2.3)
       actionpack (= 5.2.3)
       activesupport (= 5.2.3)
@@ -239,6 +249,7 @@ DEPENDENCIES
   bundler-audit
   byebug
   devise
+  devise_security_extension!
   doorkeeper (~> 4.4)
   fakeweb
   fhir_client (~> 3.0.5)
@@ -251,6 +262,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rack-cors
   rails (~> 5.2.0)
+  rails_email_validator
   rerun
   rubocop (~> 0.69.0)
   spring
@@ -261,4 +273,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,13 +15,4 @@ class User < ApplicationRecord
                 last_name: last_name,
                 user_id: id).save
   end
-
-  #validate :password_complexity
-  
-  #def password_complexity
-    # Regexp extracted from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
-    #return if password.blank? || password =~ /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/
-    #
-    #errors.add :password, 'Complexity requirement not met. Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character'
-  #end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :secure_validatable
 
   has_many :profiles
   validates :first_name, :last_name, presence: true
@@ -15,4 +15,13 @@ class User < ApplicationRecord
                 last_name: last_name,
                 user_id: id).save
   end
+
+  #validate :password_complexity
+  
+  #def password_complexity
+    # Regexp extracted from https://stackoverflow.com/questions/19605150/regex-for-password-must-contain-at-least-eight-characters-at-least-one-number-a
+    #return if password.blank? || password =~ /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/
+    #
+    #errors.add :password, 'Complexity requirement not met. Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character'
+  #end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -163,12 +163,12 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  #config.password_length = 6..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  #config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -163,12 +163,12 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  #config.password_length = 6..128
+  # config.password_length = 6..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  #config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/devise_security_extension.rb
+++ b/config/initializers/devise_security_extension.rb
@@ -7,7 +7,7 @@ Devise.setup do |config|
 
   # Regexp extracted from https://stackoverflow.com/questions/19605150/ 
   # Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character
-  config.password_regex = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/ 
+  config.password_regex = /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}/ 
 
   # How many passwords to keep in archive
   # config.password_archiving_count = 5

--- a/config/initializers/devise_security_extension.rb
+++ b/config/initializers/devise_security_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Devise.setup do |config|
   # ==> Security Extension
   # Configure security extension for devise
@@ -5,9 +7,9 @@ Devise.setup do |config|
   # Should the password expire (e.g 3.months)
   # config.expire_password_after = false
 
-  # Regexp extracted from https://stackoverflow.com/questions/19605150/ 
+  # Regexp extracted from https://stackoverflow.com/questions/19605150/
   # Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character
-  config.password_regex = /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}/ 
+  config.password_regex = /(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}/
 
   # How many passwords to keep in archive
   # config.password_archiving_count = 5

--- a/config/initializers/devise_security_extension.rb
+++ b/config/initializers/devise_security_extension.rb
@@ -1,0 +1,39 @@
+Devise.setup do |config|
+  # ==> Security Extension
+  # Configure security extension for devise
+
+  # Should the password expire (e.g 3.months)
+  # config.expire_password_after = false
+
+  # Regexp extracted from https://stackoverflow.com/questions/19605150/ 
+  # Length should be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character
+  config.password_regex = /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9])(?=.*?[#?!@$%^&*-]).{8,70}$/ 
+
+  # How many passwords to keep in archive
+  # config.password_archiving_count = 5
+
+  # Deny old password (true, false, count)
+  # config.deny_old_passwords = true
+
+  # enable email validation for :secure_validatable. (true, false, validation_options)
+  # dependency: need an email validator like rails_email_validator
+  config.email_validation = true
+
+  # captcha integration for recover form
+  # config.captcha_for_recover = true
+
+  # captcha integration for sign up form
+  # config.captcha_for_sign_up = true
+
+  # captcha integration for sign in form
+  # config.captcha_for_sign_in = true
+
+  # captcha integration for unlock form
+  # config.captcha_for_unlock = true
+
+  # captcha integration for confirmation form
+  # config.captcha_for_confirmation = true
+
+  # Time period for account expiry from last_activity_at
+  # config.expire_after = 90.days
+end

--- a/config/locales/devise.security_extension.en.yml
+++ b/config/locales/devise.security_extension.en.yml
@@ -1,0 +1,17 @@
+en:
+  errors:
+    messages:
+      taken_in_past: "was used previously."
+      equal_to_current_password: "must be different than the current password."
+      password_format: "Length must be 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character" #"must contain big, small letters and digits"
+  devise:
+    invalid_captcha: "The captcha input was invalid."
+    invalid_security_question: "The security question answer was invalid."
+    paranoid_verify:
+      code_required: "Please enter the code our support team provided"
+    password_expired:
+      updated: "Your new password is saved."
+      change_required: "Your password is expired. Please renew your password."
+    failure:
+      session_limited: 'Your login credentials were used in another browser. Please sign in again to continue in this browser.'
+      expired: 'Your account has expired due to inactivity. Please contact the site administrator.'


### PR DESCRIPTION
Adding devise security extension (gem) to configure password complexity with regex. Currently the password complexity is set to require 8-70 characters and include: 1 uppercase, 1 lowercase, 1 digit and 1 special character. 