### PR TITLE
Add end-point to allow file uploads

### DIFF
--- a/app/controllers/api/pilot/uploaded_documents_controller.rb
+++ b/app/controllers/api/pilot/uploaded_documents_controller.rb
@@ -3,7 +3,7 @@
 module Api
   module Pilot
     class UploadedDocumentsController < ApplicationController
-      before_action :set_uploaded_document, only: %i[show destroy]
+      before_action :set_uploaded_document, only: %i[show download destroy]
 
       # GET /api/pilot/uploaded_documents
       def index
@@ -20,6 +20,14 @@ module Api
       # This is kept to download metadata
       def show
         render json: @uploaded_document
+      end
+
+      # GET /api/pilot/uploaded_documents/1/download
+      def download
+        # First, make sure that the current active user is allowed to do this
+        return render json: { 'error': 'Invalid profile for current access token' }, status: :forbidden unless profile_owned_by_current_user?(@uploaded_document.profile)
+
+        redirect_to rails_blob_path(@uploaded_document.document, disposition: "attachment")
       end
 
       # POST /api/pilot/uploaded_documents

--- a/app/controllers/api/pilot/uploaded_documents_controller.rb
+++ b/app/controllers/api/pilot/uploaded_documents_controller.rb
@@ -25,9 +25,11 @@ module Api
       # GET /api/pilot/uploaded_documents/1/download
       def download
         # First, make sure that the current active user is allowed to do this
-        return render json: { 'error': 'Invalid profile for current access token' }, status: :forbidden unless profile_owned_by_current_user?(@uploaded_document.profile)
+        unless profile_owned_by_current_user?(@uploaded_document.profile)
+          return render json: { 'error': 'Invalid profile for current access token' }, status: :forbidden
+        end
 
-        redirect_to rails_blob_path(@uploaded_document.document, disposition: "attachment")
+        redirect_to rails_blob_path(@uploaded_document.document, disposition: 'attachment')
       end
 
       # POST /api/pilot/uploaded_documents

--- a/app/controllers/api/pilot/uploaded_documents_controller.rb
+++ b/app/controllers/api/pilot/uploaded_documents_controller.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Api
+  module Pilot
+    class UploadedDocumentsController < ApplicationController
+      before_action :set_uploaded_document, only: %i[show destroy]
+
+      # GET /api/pilot/uploaded_documents
+      def index
+        # Grab just the uploaded documents for the given profile
+        profile = Profile.find params[:profile_id]
+        return render json: { 'error': 'Invalid profile: does not belong to access token' }, status: :forbidden unless profile_owned_by_current_user?(profile)
+
+        @uploaded_documents = profile.uploaded_documents
+
+        render json: @uploaded_documents
+      end
+
+      # GET /api/pilot/uploaded_documents/1
+      # This is kept to download metadata
+      def show
+        render json: @uploaded_document
+      end
+
+      # POST /api/pilot/uploaded_documents
+      def create
+        @uploaded_document = UploadedDocument.new(uploaded_document_params)
+        # Check to make sure the profile_id given belongs to the current user
+
+        return render json: { 'error': 'Bad profile ID' }, status: :forbidden if @uploaded_document.profile.nil?
+
+        unless profile_owned_by_current_user?(@uploaded_document.profile)
+          return render json: { 'error': 'Invalid profile: does not belong to access token' }, status: :forbidden
+        end
+
+        # Note that this doesn't mark document as permitted and wouldn't work if
+        # passed to new. Which doesn't matter in this case
+        document = params.require(:uploaded_document).require(:document)
+        @uploaded_document.document.attach(document)
+
+        if @uploaded_document.save
+          render json: @uploaded_document, status: :created, location: api_pilot_uploaded_document_url(@uploaded_document)
+        else
+          render json: @uploaded_document.errors, status: :unprocessable_entity
+        end
+      end
+
+      # PATCH/PUT /api/pilot/uploaded_documents/1
+      # def update
+      #   if @uploaded_document.update(uploaded_document_params)
+      #     render json: @uploaded_document
+      #   else
+      #     render json: @uploaded_document.errors, status: :unprocessable_entity
+      #   end
+      # end
+
+      # DELETE /api/pilot/uploaded_documents/1
+      def destroy
+        @uploaded_document.destroy
+      end
+
+      private
+
+      def set_uploaded_document
+        @uploaded_document = UploadedDocument.find(params[:id])
+      end
+
+      # Only allow a trusted parameter "white list" through.
+      def uploaded_document_params
+        params.require(:uploaded_document).permit(:profile_id)
+      end
+    end
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,6 +19,14 @@ class ApplicationController < ActionController::API
     User.find(doorkeeper_token.resource_owner_id) if doorkeeper_token
   end
 
+  # Checks to make sure a given profile belongs to the current user
+  def profile_owned_by_current_user?(profile)
+    user = current_resource_owner
+    return false if user.nil?
+
+    profile.user_id == user.id
+  end
+
   # Function to update the audit log as new events occur in a user's account.
   def update_log
     recorded_user = begin

--- a/app/models/profile.rb
+++ b/app/models/profile.rb
@@ -30,6 +30,8 @@ class Profile < ApplicationRecord
   # resources are the raw resources that are created from transactions, they
   # do not equate to the currated data models resources
   has_many :resources
+  # These are the non-FHIR documents uploaded by the user
+  has_many :uploaded_documents
 
   def has_provider?(provider_id)
     return false if provider_id.nil?

--- a/app/models/uploaded_document.rb
+++ b/app/models/uploaded_document.rb
@@ -4,4 +4,12 @@
 class UploadedDocument < ApplicationRecord
   belongs_to :profile
   has_one_attached :document
+
+  def as_json(*args)
+    json = super
+    if document.attached?
+      json[:filename] = document.filename
+    end
+    json
+  end
 end

--- a/app/models/uploaded_document.rb
+++ b/app/models/uploaded_document.rb
@@ -7,9 +7,7 @@ class UploadedDocument < ApplicationRecord
 
   def as_json(*args)
     json = super
-    if document.attached?
-      json[:filename] = document.filename
-    end
+    json[:filename] = document.filename if document.attached?
     json
   end
 end

--- a/app/models/uploaded_document.rb
+++ b/app/models/uploaded_document.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+# A document that the user has uploaded.
+class UploadedDocument < ApplicationRecord
+  belongs_to :profile
+  has_one_attached :document
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,12 @@ Rails.application.routes.draw do
         resources cm.to_s.classify.to_sym, controller: cm, only: %i[index show]
       end
     end
+    # A custom namespace for the pilot API that's being used to test new features
+    namespace :pilot do
+      # The uploaded documents resource current exists outside of the main API
+      # Currently they can't be updated, but can be created, read, and deleted.
+      resources :uploaded_documents, except: %i[edit update]
+    end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,7 +42,11 @@ Rails.application.routes.draw do
     namespace :pilot do
       # The uploaded documents resource current exists outside of the main API
       # Currently they can't be updated, but can be created, read, and deleted.
-      resources :uploaded_documents, except: %i[edit update]
+      resources :uploaded_documents, except: %i[edit update] do
+        member do
+          get 'download'
+        end
+      end
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/migrate/20191122191432_create_uploaded_documents.rb
+++ b/db/migrate/20191122191432_create_uploaded_documents.rb
@@ -1,0 +1,9 @@
+class CreateUploadedDocuments < ActiveRecord::Migration[5.2]
+  def change
+    create_table :uploaded_documents do |t|
+      t.references :profile, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_24_180103) do
+ActiveRecord::Schema.define(version: 2019_11_22_191432) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -417,6 +417,13 @@ ActiveRecord::Schema.define(version: 2019_07_24_180103) do
     t.index ["user_id"], name: "index_resources_on_user_id"
   end
 
+  create_table "uploaded_documents", force: :cascade do |t|
+    t.bigint "profile_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["profile_id"], name: "index_uploaded_documents_on_profile_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "first_name", null: false
     t.string "last_name", null: false
@@ -439,4 +446,5 @@ ActiveRecord::Schema.define(version: 2019_07_24_180103) do
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
   add_foreign_key "providers", "providers", column: "parent_id"
+  add_foreign_key "uploaded_documents", "profiles"
 end

--- a/test/controllers/api/pilot/uploaded_documents_controller_test.rb
+++ b/test/controllers/api/pilot/uploaded_documents_controller_test.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Api
+  module Pilot
+    class UploadedDocumentsControllerTest < ActionDispatch::IntegrationTest
+      setup do
+        @user = users(:harry)
+        @token = generate_token(@user.id)
+        @profile = @user.profiles.first
+      end
+
+      test 'should get index' do
+        get api_pilot_uploaded_documents_url, params: { profile_id: @profile.to_param, access_token: @token.token }
+        assert_response :success
+      end
+
+      test 'should create uploaded_document' do
+        assert_difference('UploadedDocument.count') do
+          # Upload a document.
+          document = fixture_file_upload('files/uploaded_documents/document.txt')
+          post api_pilot_uploaded_documents_url, params:
+          {
+            uploaded_document: { profile_id: @profile.to_param, document: document },
+            access_token: @token.token
+          }
+          assert_response 201
+        end
+      end
+
+      # test 'should show uploaded_document' do
+      #   get uploaded_document_url(@uploaded_document), as: :json
+      #   assert_response :success
+      # end
+
+      # test 'should destroy uploaded_document' do
+      #   assert_difference('UploadedDocument.count', -1) do
+      #     delete uploaded_document_url(@uploaded_document), as: :json
+      #   end
+
+      #   assert_response 204
+      # end
+    end
+  end
+end

--- a/test/fixtures/files/uploaded_documents/document.txt
+++ b/test/fixtures/files/uploaded_documents/document.txt
@@ -1,0 +1,5 @@
+This is a simple uploaded document.
+
+It is just a text file.
+
+It does nothing complicated.

--- a/test/fixtures/profiles.yml
+++ b/test/fixtures/profiles.yml
@@ -1,9 +1,5 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
 harrys_profile:
   patient_id: bc4b3cbe-9292-4098-a34a-8c60b4cd4246
   name: myself
@@ -28,8 +24,7 @@ jills_profile:
   last_name: Sotired
   gender: female
   user: harry
-# column: value
-#
+
 semas_profile:
   patient_id: 5b14691a-d9fe-4a34-b094-e09d7da8d15e
   name: Sema Vermacilli
@@ -40,13 +35,9 @@ semas_profile:
 
 
 smart_sandbox:
-    patient_id: 5b14691a-d9fe-4a34-b094-e09d7da8d15e
-    name: who
-    first_name: who
-    last_name: dat
-    gender: male
-    user: smart_sandbox
-
-
-
-# column: value
+  patient_id: 5b14691a-d9fe-4a34-b094-e09d7da8d15e
+  name: who
+  first_name: who
+  last_name: dat
+  gender: male
+  user: smart_sandbox

--- a/test/models/uploaded_document_test.rb
+++ b/test/models/uploaded_document_test.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class UploadedDocumentTest < ActiveSupport::TestCase
+  # There's really nothing to test here so there are no tests yet
+  # But the stub is kept around anyway
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This provides an endpoint that can receive files. It currently does not offer a way to download the files again. Doing that may prove to be slightly more complicated due to the way we have Doorkeeper set up for user accounts.